### PR TITLE
Fix auth, consent, and content-pipeline quality issues

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -12,6 +12,7 @@ import icon from 'astro-icon';
 import vercelAdapter from '@astrojs/vercel';
 import db from '@astrojs/db';
 import respectify from '@respectify/astro';
+import { COMMENTS_API_PATH } from './src/lib/comments-config';
 
 import astroStarlightRemarkAsides from 'astro-starlight-remark-asides';
 import remarkDirective from 'remark-directive';
@@ -46,7 +47,7 @@ export default defineConfig({
         rehypeExternalLinks,
         {
           target: '_blank',
-          rel: ['nofollow, noopener, noreferrer'],
+          rel: ['nofollow', 'noopener', 'noreferrer'],
         },
       ],
     ],
@@ -59,7 +60,7 @@ export default defineConfig({
   integrations: [
     db(),
     respectify({
-      commentsApiPath: '/api/comments',
+      commentsApiPath: COMMENTS_API_PATH,
       getPostUrl: (slug, site) => `${site.replace(/\/$/, '')}/posts/${slug}/`,
     }),
     icon(),

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "astro build --remote",
     "build:ci": "ASTRO_DATABASE_FILE=./.astro/content.db astro build",
     "build:check": "astro check && astro build",
-    "lint": "prettier --write  \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\" && eslint --fix \"src/**/*.{js,ts,jsx,tsx,astro}\"",
+    "lint": "prettier --check \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\" && eslint \"src/**/*.{js,ts,jsx,tsx,astro}\"",
+    "lint:fix": "prettier --write \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\" && eslint --fix \"src/**/*.{js,ts,jsx,tsx,astro}\"",
     "prebuild:check": "npm run lint",
     "postbuild": "pagefind --site dist/client/ && cp -r dist/client/pagefind .vercel/output/static/",
     "preview": "astro preview",
@@ -68,7 +69,6 @@
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.3"
   },
-  "packageManager": "pnpm@8.15.4",
   "engines": {
     "node": "22.x"
   }

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -16,15 +16,23 @@ export const server = {
 			}),
 			handler: async ({ email, password }, context) => {
 				if (!verifyCredentials(email, password)) {
-					logger.warn('Failed login attempt');
+					logger.error('Failed login attempt', context.clientAddress ?? 'unknown');
 					throw new ActionError({
 						code: 'UNAUTHORIZED',
 						message: 'Invalid email or password',
 					});
 				}
 
-				context.session?.set('user', email);
-				context.session?.regenerate();
+				if (!context.session) {
+					logger.error('Login succeeded but session is unavailable');
+					throw new ActionError({
+						code: 'INTERNAL_SERVER_ERROR',
+						message: 'Session unavailable',
+					});
+				}
+
+				context.session.set('user', email);
+				await context.session.regenerate();
 				logger.info('User logged in successfully');
 
 				return { success: true as const };
@@ -35,7 +43,9 @@ export const server = {
 			accept: 'json',
 			input: z.object({}),
 			handler: async (_input, context) => {
-				context.session?.destroy();
+				if (context.session) {
+					context.session.destroy();
+				}
 				logger.info('User logged out');
 
 				return { success: true as const };

--- a/src/components/AdSense.astro
+++ b/src/components/AdSense.astro
@@ -1,4 +1,6 @@
 ---
+import { siteConfig } from '@site-config';
+
 interface Props {
   slot: string;
   format?: 'horizontal' | 'fluid' | 'auto';
@@ -11,7 +13,7 @@ const { slot, format = 'auto', layout, showInDev = false } = Astro.props;
 const isProd = import.meta.env.PROD;
 const shouldShow = isProd || showInDev;
 
-const CLIENT_ID = 'ca-pub-9957327027530940';
+const clientId = siteConfig.adsense.clientId;
 
 const isHorizontal = format === 'horizontal';
 const displayStyle = isHorizontal ? 'display:block' : 'display:block; text-align:center;';
@@ -20,16 +22,16 @@ const dataAdFormat = format === 'fluid' ? 'fluid' : format;
 
 {
   shouldShow ? (
-    <>
-      <ins class="adsbygoogle" style={displayStyle} data-ad-client={CLIENT_ID} data-ad-slot={slot} data-ad-format={dataAdFormat} {...(layout && { 'data-ad-layout': layout })} {...(isHorizontal && { 'data-full-width-responsive': 'true' })} />
-      <script is:inline>
-        {(() => {
-          if (typeof window !== 'undefined') {
-            (window.adsbygoogle = window.adsbygoogle || []).push({});
-          }
-        })()}
-      </script>
-    </>
+    <ins
+      class="adsbygoogle"
+      style={displayStyle}
+      data-ad-client={clientId}
+      data-ad-slot={slot}
+      data-ad-format={dataAdFormat}
+      data-consent-ad
+      {...(layout && { 'data-ad-layout': layout })}
+      {...(isHorizontal && { 'data-full-width-responsive': 'true' })}
+    />
   ) : (
     <div class="ad-placeholder">
       <span>Advertisement Placeholder ({format})</span>

--- a/src/components/BackToTop.astro
+++ b/src/components/BackToTop.astro
@@ -1,0 +1,51 @@
+---
+interface Props {
+  /** Element id used as the intersection observer target (hero / content top). */
+  observeId: string;
+}
+
+const { observeId } = Astro.props;
+---
+
+<button
+  aria-label="Back to Top"
+  class="z-50 fixed bottom-8 end-4 flex h-10 w-10 translate-y-28 items-center justify-center rounded-full border-2 border-transparent bg-zinc-200 text-3xl opacity-0 transition-all duration-300 hover:border-zinc-400 data-[show=true]:translate-y-0 data-[show=true]:opacity-100 dark:bg-zinc-700 sm:end-8 sm:h-12 sm:w-12"
+  data-show="false"
+  data-observe-id={observeId}
+  id="to-top-btn"
+  type="button"
+>
+  <svg aria-hidden="true" class="h-6 w-6" fill="none" focusable="false" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M4.5 15.75l7.5-7.5 7.5 7.5" stroke-linecap="round" stroke-linejoin="round"></path>
+  </svg>
+</button>
+
+<script>
+  function initBackToTop() {
+    const scrollBtn = document.getElementById('to-top-btn');
+    if (!(scrollBtn instanceof HTMLButtonElement)) return;
+
+    const observeId = scrollBtn.dataset.observeId;
+    const targetHeader = observeId ? document.getElementById(observeId) : null;
+    if (!targetHeader) {
+      scrollBtn.remove();
+      return;
+    }
+
+    const callback = (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        scrollBtn.dataset.show = (!entry.isIntersecting).toString();
+      });
+    };
+
+    scrollBtn.addEventListener('click', () => {
+      document.documentElement.scrollTo({ behavior: 'smooth', top: 0 });
+    });
+
+    const observer = new IntersectionObserver(callback);
+    observer.observe(targetHeader);
+  }
+
+  initBackToTop();
+  document.addEventListener('astro:page-load', initBackToTop);
+</script>

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -20,7 +20,6 @@ const socialImageURL = new URL(ogImage ? ogImage : '/social-card.png', Astro.url
 
 <meta charset="utf-8" />
 <meta content="width=device-width, initial-scale=1.0, shrink-to-fit=no" name="viewport" />
-<meta content="IE=edge" http-equiv="X-UA-Compatible" />
 <title>{siteTitle}</title>
 
 {/* Icons / Favicon */}
@@ -41,16 +40,12 @@ const socialImageURL = new URL(ogImage ? ogImage : '/social-card.png', Astro.url
 <meta name="msapplication-TileColor" content="#ffffff" />
 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
 <meta name="theme-color" content="#ffffff" />
-<link href="/manifest.webmanifest" rel="manifest" />
 <link href={canonicalURL} rel="canonical" />
 
 {/* Primary Meta Tags */}
 <meta content={siteTitle} name="title" />
 <meta content={description} name="description" />
 <meta content={siteConfig.author} name="author" />
-
-{/* Theme Colour */}
-<meta content="" name="theme-color" />
 
 {/* Open Graph / Facebook */}
 <meta content={articleDate ? 'article' : 'website'} property="og:type" />

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -1,8 +1,16 @@
 ---
+import { siteConfig } from '@site-config';
 
+const adsenseClientId = siteConfig.adsense.clientId;
 ---
 
-<div id="cookie-banner" class="fixed bottom-0 left-0 right-0 z-50 hidden border-t border-gray-300 bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-900" role="alert" aria-label="Cookie consent">
+<div
+  id="cookie-banner"
+  class="fixed bottom-0 left-0 right-0 z-50 hidden border-t border-gray-300 bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+  role="alert"
+  aria-label="Cookie consent"
+  data-adsense-client={adsenseClientId}
+>
   <div class="mx-auto flex max-w-3xl flex-col items-center gap-3 sm:flex-row sm:justify-between">
     <p class="text-sm text-gray-700 dark:text-gray-300">
       This site uses cookies for analytics and advertising.
@@ -19,6 +27,8 @@
   (function () {
     var CONSENT_KEY = 'cookie-consent';
     var GTM_ID = 'AW-994270092';
+    var banner = document.getElementById('cookie-banner');
+    var ADSENSE_CLIENT_ID = (banner && banner.getAttribute('data-adsense-client')) || '';
 
     function loadGTM() {
       if (document.querySelector('script[src*="googletagmanager"]')) return;
@@ -34,14 +44,43 @@
       gtag('config', GTM_ID);
     }
 
+    function loadAdSense() {
+      if (!ADSENSE_CLIENT_ID) return;
+      if (document.querySelector('script[src*="adsbygoogle.js"]')) {
+        fillAds();
+        return;
+      }
+      var s = document.createElement('script');
+      s.src = 'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=' + ADSENSE_CLIENT_ID;
+      s.async = true;
+      s.crossOrigin = 'anonymous';
+      s.onload = fillAds;
+      document.head.appendChild(s);
+    }
+
+    function fillAds() {
+      window.adsbygoogle = window.adsbygoogle || [];
+      var slots = document.querySelectorAll('ins.adsbygoogle[data-consent-ad]:not([data-adsbygoogle-status])');
+      for (var i = 0; i < slots.length; i++) {
+        try {
+          window.adsbygoogle.push({});
+        } catch (e) {
+          /* ignore duplicate push errors */
+        }
+      }
+    }
+
+    function loadMarketing() {
+      loadGTM();
+      loadAdSense();
+    }
+
     function hideBanner() {
-      var banner = document.getElementById('cookie-banner');
       if (banner) banner.classList.add('hidden');
       document.body.style.paddingBottom = '';
     }
 
     function showBanner() {
-      var banner = document.getElementById('cookie-banner');
       if (banner) {
         banner.classList.remove('hidden');
         document.body.style.paddingBottom = banner.offsetHeight + 'px';
@@ -51,7 +90,7 @@
     var consent = localStorage.getItem(CONSENT_KEY);
 
     if (consent === 'accepted') {
-      loadGTM();
+      loadMarketing();
     } else if (!consent) {
       showBanner();
 
@@ -61,7 +100,7 @@
       if (acceptBtn) {
         acceptBtn.addEventListener('click', function () {
           localStorage.setItem(CONSENT_KEY, 'accepted');
-          loadGTM();
+          loadMarketing();
           hideBanner();
         });
       }

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -103,13 +103,14 @@ import '@pagefind/default-ui/css/ui.css';
     }
 
     connectedCallback() {
-      // Listen for keyboard shortcut
       window.addEventListener('keydown', this.onWindowKeydown);
 
-      // only add pagefind in production
       if (import.meta.env.DEV) return;
+      if (this.querySelector('.pagefind-ui')) return;
+
       const onIdle = window.requestIdleCallback || ((cb) => setTimeout(cb, 1));
       onIdle(async () => {
+        if (this.querySelector('.pagefind-ui')) return;
         const { PagefindUI } = await import('@pagefind/default-ui');
         new PagefindUI({
           baseUrl: import.meta.env.BASE_URL,
@@ -123,6 +124,10 @@ import '@pagefind/default-ui/css/ui.css';
 
     disconnectedCallback() {
       window.removeEventListener('keydown', this.onWindowKeydown);
+      window.removeEventListener('click', this.onWindowClick);
+      if (this.dialog?.open) {
+        this.dialog.close();
+      }
     }
   }
 

--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -23,37 +23,39 @@ const twitterUrl = `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${
 const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`;
 const linkedinUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
 const emailUrl = `mailto:?subject=${encodedTitle}&body=${encodedDescription}%0A%0A${encodedUrl}`;
+
+const focusRing = 'focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 dark:focus:ring-offset-gray-900';
 ---
 
-<div class="not-prose share-buttons mt-10 border-t border-gray-200 pt-8 dark:border-gray-700">
+<share-buttons class="not-prose share-buttons mt-10 block border-t border-gray-200 pt-8 dark:border-gray-700">
   <h3 class="mb-4 text-lg font-medium text-accent-2">Share this post</h3>
   <div class="flex flex-wrap gap-3">
-    <button id="web-share-btn" class="inline-flex items-center rounded-md bg-accent-2 px-4 py-2 text-sm text-white transition hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-accent-1 focus:ring-offset-2 dark:focus:ring-offset-gray-900" aria-label="Share this post" data-title={title} data-description={description} data-url={fullUrl}>
+    <button data-web-share class:list={['inline-flex items-center rounded-md bg-accent-2 px-4 py-2 text-sm text-white transition hover:bg-opacity-90', focusRing]} aria-label="Share this post" data-title={title} data-description={description} data-url={fullUrl}>
       <Icon name="mdi:share" class="mr-2 h-5 w-5" aria-hidden="true" />
       <span>Share</span>
     </button>
 
-    <a href={twitterUrl} target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-md bg-[#000000] px-4 py-2 text-sm text-white transition hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-accent-1 focus:ring-offset-2 dark:focus:ring-offset-gray-900" aria-label="Share on Twitter">
+    <a href={twitterUrl} target="_blank" rel="noopener noreferrer" class:list={['inline-flex items-center rounded-md bg-[#000000] px-4 py-2 text-sm text-white transition hover:bg-opacity-90', focusRing]} aria-label="Share on Twitter">
       <Icon name="mdi:twitter" class="mr-2 h-5 w-5" aria-hidden="true" />
       <span>X / Twitter</span>
     </a>
 
-    <a href={facebookUrl} target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-md bg-[#1877F2] px-4 py-2 text-sm text-white transition hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-accent-1 focus:ring-offset-2 dark:focus:ring-offset-gray-900" aria-label="Share on Facebook">
+    <a href={facebookUrl} target="_blank" rel="noopener noreferrer" class:list={['inline-flex items-center rounded-md bg-[#1877F2] px-4 py-2 text-sm text-white transition hover:bg-opacity-90', focusRing]} aria-label="Share on Facebook">
       <Icon name="mdi:facebook" class="mr-2 h-5 w-5" aria-hidden="true" />
       <span>Facebook</span>
     </a>
 
-    <a href={linkedinUrl} target="_blank" rel="noopener noreferrer" class="inline-flex items-center rounded-md bg-[#0A66C2] px-4 py-2 text-sm text-white transition hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-accent-1 focus:ring-offset-2 dark:focus:ring-offset-gray-900" aria-label="Share on LinkedIn">
+    <a href={linkedinUrl} target="_blank" rel="noopener noreferrer" class:list={['inline-flex items-center rounded-md bg-[#0A66C2] px-4 py-2 text-sm text-white transition hover:bg-opacity-90', focusRing]} aria-label="Share on LinkedIn">
       <Icon name="mdi:linkedin" class="mr-2 h-5 w-5" aria-hidden="true" />
       <span>LinkedIn</span>
     </a>
 
-    <a href={emailUrl} class="inline-flex items-center rounded-md bg-[#4CAF50] px-4 py-2 text-sm text-white transition hover:bg-opacity-90 focus:outline-none focus:ring-2 focus:ring-accent-1 focus:ring-offset-2 dark:focus:ring-offset-gray-900" aria-label="Share via email">
+    <a href={emailUrl} class:list={['inline-flex items-center rounded-md bg-[#4CAF50] px-4 py-2 text-sm text-white transition hover:bg-opacity-90', focusRing]} aria-label="Share via email">
       <Icon name="mdi:email" class="mr-2 h-5 w-5" aria-hidden="true" />
       <span>Email</span>
     </a>
   </div>
-</div>
+</share-buttons>
 
 <script>
   import { logger } from '../lib/logger';
@@ -65,77 +67,57 @@ const emailUrl = `mailto:?subject=${encodedTitle}&body=${encodedDescription}%0A%
     const toast = document.createElement('div');
     toast.id = 'share-toast';
     toast.textContent = message;
-    toast.className = 'fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-md bg-gray-800 px-4 py-2 text-sm text-white shadow-lg dark:bg-gray-200 dark:text-gray-900';
+    toast.className =
+      'fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-md bg-gray-800 px-4 py-2 text-sm text-white shadow-lg dark:bg-gray-200 dark:text-gray-900';
     document.body.appendChild(toast);
     setTimeout(() => toast.remove(), 4000);
   }
 
-  // Web Share API support with proper cleanup
-  class ShareButtonManager {
-    private shareButton: HTMLButtonElement | null;
-    private shareLinks: NodeListOf<HTMLAnchorElement>;
+  class ShareButtonsElement extends HTMLElement {
     private shareClickHandler: (() => Promise<void>) | null = null;
-    private linkClickHandlers: Map<HTMLAnchorElement, (e: MouseEvent) => void> = new Map();
+    private linkClickHandlers = new Map<HTMLAnchorElement, (e: MouseEvent) => void>();
 
-    constructor() {
-      this.shareButton = document.getElementById('web-share-btn') as HTMLButtonElement | null;
-      this.shareLinks = document.querySelectorAll('.share-buttons a');
+    connectedCallback() {
+      const shareButton = this.querySelector<HTMLButtonElement>('[data-web-share]');
+      const shareLinks = this.querySelectorAll<HTMLAnchorElement>('a');
 
-      this.init();
-    }
-
-    init() {
-      if (!this.shareButton) {
+      if (!shareButton) {
         logger.error('Share button not found');
         return;
       }
 
       if (navigator.share) {
         this.shareClickHandler = async () => {
-          if (!this.shareButton) return;
-
           try {
-            const title = this.shareButton.dataset.title || '';
-            const description = this.shareButton.dataset.description || '';
-            const url = this.shareButton.dataset.url || '';
-
             await navigator.share({
-              title,
-              text: description,
-              url,
+              title: shareButton.dataset.title || '',
+              text: shareButton.dataset.description || '',
+              url: shareButton.dataset.url || '',
             });
           } catch (err) {
-            // Check if user cancelled (this is expected behavior)
-            if (err instanceof Error && err.name === 'AbortError') {
-              return; // User cancelled, no need to show error
-            }
+            if (err instanceof Error && err.name === 'AbortError') return;
             logger.error('Share failed:', err);
-            // Show user-friendly error message
             showShareToast('Unable to share. Please try using one of the social media buttons below.');
           }
         };
-        this.shareButton.addEventListener('click', this.shareClickHandler);
+        shareButton.addEventListener('click', this.shareClickHandler);
       } else {
-        this.shareButton.style.display = 'none';
+        shareButton.style.display = 'none';
       }
 
-      // Enhanced link behavior for social sharing
-      this.shareLinks.forEach((link) => {
+      shareLinks.forEach((link) => {
         const handler = (e: MouseEvent) => {
           try {
-            // If it's not the email link, prevent default and open in popup
             if (!link.href.startsWith('mailto:')) {
               e.preventDefault();
               const popup = window.open(link.href, 'share-popup', 'width=600,height=480');
               if (!popup) {
-                // Popup blocked - show message and open in new tab
                 showShareToast('Popup blocked. Opening in new tab instead.');
                 window.open(link.href, '_blank');
               }
             }
           } catch (err) {
             logger.error('Share error:', err);
-            // Don't prevent default - let the link work normally as fallback
           }
         };
         this.linkClickHandlers.set(link, handler);
@@ -143,22 +125,20 @@ const emailUrl = `mailto:?subject=${encodedTitle}&body=${encodedDescription}%0A%
       });
     }
 
-    cleanup() {
-      // Remove event listeners to prevent memory leaks
-      if (this.shareButton && this.shareClickHandler) {
-        this.shareButton.removeEventListener('click', this.shareClickHandler);
+    disconnectedCallback() {
+      const shareButton = this.querySelector<HTMLButtonElement>('[data-web-share]');
+      if (shareButton && this.shareClickHandler) {
+        shareButton.removeEventListener('click', this.shareClickHandler);
       }
-
       this.linkClickHandlers.forEach((handler, link) => {
         link.removeEventListener('click', handler);
       });
       this.linkClickHandlers.clear();
+      this.shareClickHandler = null;
     }
   }
 
-  // Initialize
-  const shareManager = new ShareButtonManager();
-
-  // Cleanup on page navigation (for SPAs) or beforeunload
-  window.addEventListener('beforeunload', () => shareManager.cleanup());
+  if (!customElements.get('share-buttons')) {
+    customElements.define('share-buttons', ShareButtonsElement);
+  }
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,6 +1,6 @@
 <theme-toggle class="ms-2 sm:ms-4">
   <div class="relative">
-    <button class="relative h-9 w-9 rounded-md p-2 ring-zinc-400 transition-all hover:ring-2" type="button" id="theme-button" aria-label="Toggle theme" aria-haspopup="true">
+    <button class="relative h-9 w-9 rounded-md p-2 ring-zinc-400 transition-all hover:ring-2" type="button" id="theme-button" aria-label="Toggle theme" aria-haspopup="menu" aria-expanded="false">
       <svg aria-hidden="true" class="absolute start-1/2 top-1/2 h-7 w-7 -translate-x-1/2 -translate-y-1/2 scale-100 opacity-100 transition-all dark:scale-0 dark:opacity-0" fill="none" focusable="false" id="sun-svg" stroke-width="1.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path d="M12 18C15.3137 18 18 15.3137 18 12C18 8.68629 15.3137 6 12 6C8.68629 6 6 8.68629 6 12C6 15.3137 8.68629 18 12 18Z" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path>
         <path d="M22 12L23 12" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"></path>
@@ -59,8 +59,7 @@
 </theme-toggle>
 
 <script>
-  // Note that if you fire the theme-change event outside of this component, it will not be reflected in the button's aria-checked attribute
-  import { rootInDarkMode } from '@utils';
+  // Note that if you fire the theme-change event outside of this component, it will not be reflected in the button's aria-expanded attribute
 
   class ThemeToggle extends HTMLElement {
     #controller: AbortController | undefined;
@@ -81,9 +80,9 @@
       this.#systemText = this.querySelector('#system-sync-text')!;
       this.#systemIndicator = this.querySelector('#system-sync-indicator')!;
       
-      // Set aria role value
-      this.#button.setAttribute('role', 'switch');
-      this.#button.setAttribute('aria-checked', String(rootInDarkMode()));
+      // Menu button semantics
+      this.#button.setAttribute('aria-haspopup', 'menu');
+      this.#button.setAttribute('aria-expanded', 'false');
       
       // Abort signal
       const { signal } = (this.#controller = new AbortController());
@@ -102,12 +101,22 @@
         }
         
         this.#dropdown.classList.toggle('hidden');
+        this.#button.setAttribute('aria-expanded', String(this.#dropdown.classList.contains('hidden') === false));
       }, { signal });
       
       // Handle option clicks
       this.#lightOption.addEventListener('click', () => this.setTheme('light', false), { signal });
       this.#darkOption.addEventListener('click', () => this.setTheme('dark', false), { signal });
       this.#systemOption.addEventListener('click', this.toggleSystemSync.bind(this), { signal });
+
+      // Escape closes the menu
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !this.#dropdown.classList.contains('hidden')) {
+          this.#dropdown.classList.add('hidden');
+          this.#button.setAttribute('aria-expanded', 'false');
+          this.#button.focus();
+        }
+      }, { signal });
       
       // Close dropdown when clicking outside
       document.addEventListener('click', this.handleOutsideClick.bind(this), { signal });
@@ -116,6 +125,7 @@
     handleOutsideClick(e: Event) {
       if (!this.contains(e.target as Node) && !this.#dropdown.classList.contains('hidden')) {
         this.#dropdown.classList.add('hidden');
+        this.#button.setAttribute('aria-expanded', 'false');
       }
     }
     
@@ -142,8 +152,8 @@
       if (window.themeUtils) {
         window.themeUtils.toggleSyncWithOS();
         this.updateSyncStatus();
-        this.#button.setAttribute('aria-checked', String(rootInDarkMode()));
         this.#dropdown.classList.add('hidden');
+        this.#button.setAttribute('aria-expanded', 'false');
       }
     }
     
@@ -158,9 +168,8 @@
       // Dispatch event -> ThemeProvider.astro
       document.dispatchEvent(themeChangeEvent);
       
-      // Set the aria-checked attribute
-      this.#button.setAttribute('aria-checked', String(rootInDarkMode()));
       this.#dropdown.classList.add('hidden');
+      this.#button.setAttribute('aria-expanded', 'false');
       this.updateSyncStatus();
     }
 

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -29,6 +29,9 @@ const url = Astro.url;
         </a>
       ))
     }
+    <button id="admin-logout" type="button" class="hidden px-4 py-4 text-red-600 sm:py-0 sm:hover:underline" aria-label="Log out">
+      Log out
+    </button>
   </nav>
 
   <Search />
@@ -53,22 +56,22 @@ const url = Astro.url;
 
     class MobileNavBtn extends HTMLElement {
       private headerEl!: HTMLElement;
-
-      private menuOpen!: boolean;
-
+      private menuOpen = false;
       private mobileButtonEl!: HTMLButtonElement;
+      private onKeydown = (e: KeyboardEvent) => {
+        if (e.key === 'Escape' && this.menuOpen) {
+          this.toggleMobileMenu();
+          this.mobileButtonEl.focus();
+        }
+      };
 
       toggleMobileMenu = () => {
         toggleClass(this.headerEl, 'menu-open');
-
         this.menuOpen = !this.menuOpen;
-
         this.mobileButtonEl.setAttribute('aria-expanded', this.menuOpen.toString());
       };
 
-      constructor() {
-        super();
-
+      connectedCallback() {
         const headerEl = document.getElementById('main-header');
         if (!headerEl) {
           logger.error('Header element not found');
@@ -81,25 +84,41 @@ const url = Astro.url;
           logger.error('Mobile button not found');
           return;
         }
-        this.mobileButtonEl = mobileButtonEl as HTMLButtonElement;
-
+        this.mobileButtonEl = mobileButtonEl;
         this.menuOpen = false;
-
         this.mobileButtonEl.addEventListener('click', this.toggleMobileMenu);
+        document.addEventListener('keydown', this.onKeydown);
+      }
+
+      disconnectedCallback() {
+        this.mobileButtonEl?.removeEventListener('click', this.toggleMobileMenu);
+        document.removeEventListener('keydown', this.onKeydown);
       }
     }
 
-    customElements.define('mobile-button', MobileNavBtn);
+    if (!customElements.get('mobile-button')) {
+      customElements.define('mobile-button', MobileNavBtn);
+    }
   </script>
 
   <script>
-    import { checkAuth } from '../../lib/client/auth-check';
+    import { actions } from 'astro:actions';
+    import { checkAuth, clearAuthCache } from '../../lib/client/auth-check';
 
     checkAuth().then((isAdmin) => {
       if (!isAdmin) return;
       const avatar = document.getElementById('admin-avatar');
       if (avatar) {
         avatar.classList.add('ring-4', 'ring-red-500', 'ring-offset-2');
+      }
+      const logoutBtn = document.getElementById('admin-logout');
+      if (logoutBtn) {
+        logoutBtn.classList.remove('hidden');
+        logoutBtn.addEventListener('click', async () => {
+          await actions.auth.logout({});
+          clearAuthCache();
+          window.location.href = '/';
+        });
       }
     });
   </script>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,6 +9,17 @@ function removeDupsAndLowerCase(array: string[]) {
   return Array.from(distinctItems);
 }
 
+const dateFromStringOrDate = z
+  .string()
+  .or(z.date())
+  .transform((val) => new Date(val));
+
+const optionalDateFromStringOrDate = z
+  .string()
+  .or(z.date())
+  .optional()
+  .transform((str) => (str ? new Date(str) : undefined));
+
 const post = defineCollection({
   loader: glob({ pattern: '**/[^_]*.{md,mdx}', base: './src/content/post' }),
   schema: ({ image }) =>
@@ -16,15 +27,8 @@ const post = defineCollection({
       title: z.string().max(60),
       author: z.string().optional(),
       description: z.string().min(20).max(160),
-      publishDate: z
-        .string()
-        .or(z.date())
-        .transform((val) => new Date(val)),
-      updatedDate: z
-        .string()
-        .or(z.date())
-        .optional()
-        .transform((str) => (str ? new Date(str) : undefined)),
+      publishDate: dateFromStringOrDate,
+      updatedDate: optionalDateFromStringOrDate,
       coverImage: z
         .object({
           src: image(),
@@ -34,6 +38,8 @@ const post = defineCollection({
       draft: z.boolean().default(false),
       tags: z.array(z.string()).default([]).transform(removeDupsAndLowerCase),
       ogImage: z.string().optional(),
+      /** Legacy frontmatter; routing uses the content file id. */
+      postSlug: z.string().optional(),
     }),
 });
 
@@ -55,26 +61,20 @@ const delphi = defineCollection({
       title: z.string().max(120),
       author: z.string().optional().default('Nick Hodges'),
       description: z.string().min(20).max(300),
-      publishDate: z
-        .string()
-        .or(z.date())
-        .transform((val) => new Date(val)),
-      updatedDate: z
-        .string()
-        .or(z.date())
-        .optional()
-        .transform((str) => (str ? new Date(str) : undefined)),
-      postSlug: z.string().optional(),
-      featured: z.boolean().default(false),
-      draft: z.boolean().default(false),
-      tags: z.array(z.string()).default([]).transform(removeDupsAndLowerCase),
-      ogImage: z.string().optional(),
+      publishDate: dateFromStringOrDate,
+      updatedDate: optionalDateFromStringOrDate,
       coverImage: z
         .object({
           src: image(),
           alt: z.string(),
         })
         .optional(),
+      draft: z.boolean().default(false),
+      tags: z.array(z.string()).default([]).transform(removeDupsAndLowerCase),
+      ogImage: z.string().optional(),
+      /** Legacy frontmatter; routing uses the content file id. */
+      postSlug: z.string().optional(),
+      featured: z.boolean().default(false),
     }),
 });
 

--- a/src/data/collection-helpers.test.ts
+++ b/src/data/collection-helpers.test.ts
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+/** Mirrors src/data/collection-helpers.ts sort/tag helpers (Astro-free for Node tests). */
+type DatedEntry = {
+  id: string;
+  data: {
+    publishDate: Date;
+    updatedDate: Date | undefined;
+    tags: string[];
+  };
+};
+
+function sortMDByDate<T extends DatedEntry>(posts: Array<T>): Array<T> {
+  return [...posts].sort((a, b) => {
+    const aDate = new Date(a.data.updatedDate ?? a.data.publishDate).valueOf();
+    const bDate = new Date(b.data.updatedDate ?? b.data.publishDate).valueOf();
+    return bDate - aDate;
+  });
+}
+
+function getAllTags<T extends DatedEntry>(posts: Array<T>): string[] {
+  return posts.flatMap((post) => [...post.data.tags]);
+}
+
+function getUniqueTags<T extends DatedEntry>(posts: Array<T>): string[] {
+  return [...new Set(getAllTags(posts))];
+}
+
+function getUniqueTagsWithCount<T extends DatedEntry>(posts: Array<T>): Array<[string, number]> {
+  return [...getAllTags(posts).reduce((acc, t) => acc.set(t, (acc.get(t) || 0) + 1), new Map<string, number>())].sort(
+    (a, b) => b[1] - a[1],
+  );
+}
+
+describe('collection-helpers logic', () => {
+  const posts: DatedEntry[] = [
+    {
+      id: 'older',
+      data: {
+        publishDate: new Date('2020-01-01'),
+        updatedDate: undefined,
+        tags: ['delphi', 'testing'],
+      },
+    },
+    {
+      id: 'newer',
+      data: {
+        publishDate: new Date('2021-01-01'),
+        updatedDate: new Date('2022-06-01'),
+        tags: ['testing', 'astro'],
+      },
+    },
+  ];
+
+  it('sortMDByDate returns a new array newest-first without mutating input', () => {
+    const originalOrder = posts.map((p) => p.id);
+    const sorted = sortMDByDate(posts);
+
+    assert.deepEqual(
+      sorted.map((p) => p.id),
+      ['newer', 'older'],
+    );
+    assert.deepEqual(
+      posts.map((p) => p.id),
+      originalOrder,
+    );
+  });
+
+  it('getUniqueTags dedupes tags', () => {
+    assert.deepEqual(getUniqueTags(posts).sort(), ['astro', 'delphi', 'testing']);
+  });
+
+  it('getUniqueTagsWithCount sorts by frequency', () => {
+    assert.deepEqual(getUniqueTagsWithCount(posts), [
+      ['testing', 2],
+      ['delphi', 1],
+      ['astro', 1],
+    ]);
+  });
+});

--- a/src/data/collection-helpers.ts
+++ b/src/data/collection-helpers.ts
@@ -1,0 +1,44 @@
+import type { CollectionEntry } from 'astro:content';
+import { getCollection } from 'astro:content';
+
+type BlogCollection = 'post' | 'delphi';
+
+/** Minimal shape needed for date sorting and tag helpers. */
+type DatedEntry = {
+  data: {
+    publishDate: Date;
+    updatedDate: Date | undefined;
+    draft?: boolean | undefined;
+    tags: string[];
+  };
+};
+
+/** Filters out draft posts in production. */
+export async function getPublishedEntries<C extends BlogCollection>(collection: C): Promise<Array<CollectionEntry<C>>> {
+  return await getCollection(collection, ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+}
+
+/** Returns a new array sorted by updatedDate (or publishDate), newest first. */
+export function sortMDByDate<T extends DatedEntry>(posts: Array<T>): Array<T> {
+  return [...posts].sort((a, b) => {
+    const aDate = new Date(a.data.updatedDate ?? a.data.publishDate).valueOf();
+    const bDate = new Date(b.data.updatedDate ?? b.data.publishDate).valueOf();
+    return bDate - aDate;
+  });
+}
+
+export function getAllTags<T extends DatedEntry>(posts: Array<T>): string[] {
+  return posts.flatMap((post) => [...post.data.tags]);
+}
+
+export function getUniqueTags<T extends DatedEntry>(posts: Array<T>): string[] {
+  return [...new Set(getAllTags(posts))];
+}
+
+export function getUniqueTagsWithCount<T extends DatedEntry>(posts: Array<T>): Array<[string, number]> {
+  return [...getAllTags(posts).reduce((acc, t) => acc.set(t, (acc.get(t) || 0) + 1), new Map<string, number>())].sort(
+    (a, b) => b[1] - a[1],
+  );
+}

--- a/src/data/delphi.ts
+++ b/src/data/delphi.ts
@@ -1,32 +1,32 @@
 import type { CollectionEntry } from 'astro:content';
-import { getCollection } from 'astro:content';
+import {
+  getAllTags as getAllTagsHelper,
+  getPublishedEntries,
+  getUniqueTags as getUniqueTagsHelper,
+  getUniqueTagsWithCount as getUniqueTagsWithCountHelper,
+  sortMDByDate as sortMDByDateHelper,
+} from './collection-helpers';
 
 /** Note: this function filters out draft posts based on the environment */
 export async function getAllDelphiPosts(): Promise<Array<CollectionEntry<'delphi'>>> {
-  return await getCollection('delphi', ({ data }) => {
-    return import.meta.env.PROD ? data.draft !== true : true;
-  });
+  return getPublishedEntries('delphi');
 }
 
 export function sortMDByDate(posts: Array<CollectionEntry<'delphi'>>) {
-  return posts.sort((a, b) => {
-    const aDate = new Date(a.data.updatedDate ?? a.data.publishDate).valueOf();
-    const bDate = new Date(b.data.updatedDate ?? b.data.publishDate).valueOf();
-    return bDate - aDate;
-  });
+  return sortMDByDateHelper(posts);
 }
 
 /** Note: This function doesn't filter draft posts, pass it the result of getAllDelphiPosts above to do so. */
 export function getAllTags(posts: Array<CollectionEntry<'delphi'>>) {
-  return posts.flatMap((post) => [...post.data.tags]);
+  return getAllTagsHelper(posts);
 }
 
 /** Note: This function doesn't filter draft posts, pass it the result of getAllDelphiPosts above to do so. */
 export function getUniqueTags(posts: Array<CollectionEntry<'delphi'>>) {
-  return [...new Set(getAllTags(posts))];
+  return getUniqueTagsHelper(posts);
 }
 
 /** Note: This function doesn't filter draft posts, pass it the result of getAllDelphiPosts above to do so. */
 export function getUniqueTagsWithCount(posts: Array<CollectionEntry<'delphi'>>): Array<[string, number]> {
-  return [...getAllTags(posts).reduce((acc, t) => acc.set(t, (acc.get(t) || 0) + 1), new Map<string, number>())].sort((a, b) => b[1] - a[1]);
+  return getUniqueTagsWithCountHelper(posts);
 }

--- a/src/data/post.ts
+++ b/src/data/post.ts
@@ -1,32 +1,32 @@
 import type { CollectionEntry } from 'astro:content';
-import { getCollection } from 'astro:content';
+import {
+  getAllTags as getAllTagsHelper,
+  getPublishedEntries,
+  getUniqueTags as getUniqueTagsHelper,
+  getUniqueTagsWithCount as getUniqueTagsWithCountHelper,
+  sortMDByDate as sortMDByDateHelper,
+} from './collection-helpers';
 
 /** Note: this function filters out draft posts based on the environment */
 export async function getAllPosts(): Promise<Array<CollectionEntry<'post'>>> {
-  return await getCollection('post', ({ data }) => {
-    return import.meta.env.PROD ? data.draft !== true : true;
-  });
+  return getPublishedEntries('post');
 }
 
 export function sortMDByDate(posts: Array<CollectionEntry<'post'>>) {
-  return posts.sort((a, b) => {
-    const aDate = new Date(a.data.updatedDate ?? a.data.publishDate).valueOf();
-    const bDate = new Date(b.data.updatedDate ?? b.data.publishDate).valueOf();
-    return bDate - aDate;
-  });
+  return sortMDByDateHelper(posts);
 }
 
 /** Note: This function doesn't filter draft posts, pass it the result of getAllPosts above to do so. */
 export function getAllTags(posts: Array<CollectionEntry<'post'>>) {
-  return posts.flatMap((post) => [...post.data.tags]);
+  return getAllTagsHelper(posts);
 }
 
 /** Note: This function doesn't filter draft posts, pass it the result of getAllPosts above to do so. */
 export function getUniqueTags(posts: Array<CollectionEntry<'post'>>) {
-  return [...new Set(getAllTags(posts))];
+  return getUniqueTagsHelper(posts);
 }
 
 /** Note: This function doesn't filter draft posts, pass it the result of getAllPosts above to do so. */
 export function getUniqueTagsWithCount(posts: Array<CollectionEntry<'post'>>): Array<[string, number]> {
-  return [...getAllTags(posts).reduce((acc, t) => acc.set(t, (acc.get(t) || 0) + 1), new Map<string, number>())].sort((a, b) => b[1] - a[1]);
+  return getUniqueTagsWithCountHelper(posts);
 }

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -17,15 +17,11 @@ interface Props {
 const {
   meta: { articleDate, description = siteConfig.description, ogImage, title },
 } = Astro.props;
-
-const isProd = import.meta.env.PROD;
-const ADSENSE_CLIENT_ID = 'ca-pub-9957327027530940';
 ---
 
 <html lang={siteConfig.lang}>
   <head>
     <BaseHead articleDate={articleDate} description={description} ogImage={ogImage} title={title} />
-    {isProd && <script is:inline async src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_CLIENT_ID}`} crossorigin="anonymous" />}
   </head>
 
   <body>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -1,20 +1,23 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import { render } from 'astro:content';
+import type { CollectionEntry, RenderResult } from 'astro:content';
 
 import BlogHero from '@components/blog/Hero.astro';
 import TOC from '@components/blog/TOC.astro';
 import ShareButtons from '@components/ShareButtons.astro';
 import NewsletterSignup from '@components/NewsletterSignup.astro';
+import BackToTop from '@components/BackToTop.astro';
 import CommentSection from '@respectify/astro/components/CommentSection.astro';
+import { COMMENTS_API_PATH } from '../lib/comments-config';
 
 import BaseLayout from './Base.astro';
 
 interface Props {
   post: CollectionEntry<'post'> | CollectionEntry<'delphi'>;
+  headings: RenderResult['headings'];
+  minutesRead?: string;
 }
 
-const { post } = Astro.props;
+const { post, headings, minutesRead } = Astro.props;
 const {
   data: { description, ogImage, publishDate, title, updatedDate },
   id,
@@ -22,55 +25,36 @@ const {
 const socialImage = ogImage ?? `/og-image/${id}.png`;
 const articleDate = updatedDate?.toISOString() ?? publishDate.toISOString();
 const postUrl = `posts/${id}`;
-
-const { headings, remarkPluginFrontmatter } = await render(post);
 ---
 
 <BaseLayout meta={{ articleDate, description, ogImage: socialImage, title }}>
   <div class="gap-x-10 lg:flex lg:items-start">
     {!!headings.length && <TOC headings={headings} />}
     <article class="prose prose-cactus flex-grow break-words" data-pagefind-body>
-      <div id="blog-hero"><BlogHero content={post} minutesRead={remarkPluginFrontmatter.minutesRead} /></div>
+      <div id="blog-hero">
+        {minutesRead !== undefined ? <BlogHero content={post} minutesRead={minutesRead} /> : <BlogHero content={post} />}
+      </div>
 
       <div class="mt-12 max-w-3xl">
         <slot />
       </div>
 
-      <ShareButtons title={title} url={postUrl} description={description} />
+      <div data-pagefind-ignore>
+        <ShareButtons title={title} url={postUrl} description={description} />
 
-      <NewsletterSignup />
+        <NewsletterSignup />
 
-      <div class="mt-12 border-t border-gray-200 dark:border-gray-700 pt-8 not-prose">
-        <CommentSection
-          postSlug={id}
-          apiPath="/api/comments"
-          enableDelete
-          style="--rf-accent: hsl(var(--theme-accent)); --rf-accent-hover: hsl(var(--theme-accent-2));"
-        />
+        <div class="mt-12 border-t border-gray-200 dark:border-gray-700 pt-8 not-prose">
+          <CommentSection
+            postSlug={id}
+            apiPath={COMMENTS_API_PATH}
+            enableDelete
+            style="--rf-accent: hsl(var(--theme-accent)); --rf-accent-hover: hsl(var(--theme-accent-2));"
+          />
+        </div>
       </div>
     </article>
   </div>
 
-  <button aria-label="Back to Top" class="z-90 fixed bottom-8 end-4 flex h-10 w-10 translate-y-28 items-center justify-center rounded-full border-2 border-transparent bg-zinc-200 text-3xl opacity-0 transition-all duration-300 hover:border-zinc-400 data-[show=true]:translate-y-0 data-[show=true]:opacity-100 dark:bg-zinc-700 sm:end-8 sm:h-12 sm:w-12" data-show="false" id="to-top-btn">
-    <svg aria-hidden="true" class="h-6 w-6" fill="none" focusable="false" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <path d="M4.5 15.75l7.5-7.5 7.5 7.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    </svg>
-  </button>
+  <BackToTop observeId="blog-hero" />
 </BaseLayout>
-<script>
-  const scrollBtn = document.getElementById('to-top-btn') as HTMLButtonElement;
-  const targetHeader = document.getElementById('blog-hero') as HTMLDivElement;
-
-  function callback(entries: IntersectionObserverEntry[]) {
-    entries.forEach((entry) => {
-      scrollBtn.dataset.show = (!entry.isIntersecting).toString();
-    });
-  }
-
-  scrollBtn.addEventListener('click', () => {
-    document.documentElement.scrollTo({ behavior: 'smooth', top: 0 });
-  });
-
-  const observer = new IntersectionObserver(callback);
-  observer.observe(targetHeader);
-</script>

--- a/src/layouts/InfoPost.astro
+++ b/src/layouts/InfoPost.astro
@@ -1,21 +1,20 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import { render } from 'astro:content';
+import type { CollectionEntry, RenderResult } from 'astro:content';
 import TOC from '@components/blog/TOC.astro';
+import BackToTop from '@components/BackToTop.astro';
 import BaseLayout from './Base.astro';
 
 interface Props {
   info: CollectionEntry<'info'>;
+  headings: RenderResult['headings'];
 }
 
-const { info } = Astro.props;
+const { info, headings } = Astro.props;
 const {
   data: { ogImage, title },
   id,
 } = info;
 const socialImage = ogImage ?? `/og-image/${id}.png`;
-
-const { headings } = await render(info);
 ---
 
 <BaseLayout meta={{ ogImage: socialImage, title }}>
@@ -28,30 +27,5 @@ const { headings } = await render(info);
     </article>
   </div>
 
-  <button aria-label="Back to Top" class="z-90 fixed bottom-8 end-4 flex h-10 w-10 translate-y-28 items-center justify-center rounded-full border-2 border-transparent bg-zinc-200 text-3xl opacity-0 transition-all duration-300 hover:border-zinc-400 data-[show=true]:translate-y-0 data-[show=true]:opacity-100 dark:bg-zinc-700 sm:end-8 sm:h-12 sm:w-12" data-show="false" id="to-top-btn">
-    <svg aria-hidden="true" class="h-6 w-6" fill="none" focusable="false" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-      <path d="M4.5 15.75l7.5-7.5 7.5 7.5" stroke-linecap="round" stroke-linejoin="round"></path>
-    </svg>
-  </button>
+  <BackToTop observeId="info-content" />
 </BaseLayout>
-<script>
-  const scrollBtn = document.getElementById('to-top-btn') as HTMLButtonElement;
-  const targetHeader = document.getElementById('info-content') as HTMLDivElement;
-
-  if (!scrollBtn || !targetHeader) {
-    scrollBtn?.remove();
-  } else {
-    function callback(entries: IntersectionObserverEntry[]) {
-      entries.forEach((entry) => {
-        scrollBtn.dataset.show = (!entry.isIntersecting).toString();
-      });
-    }
-
-    scrollBtn.addEventListener('click', () => {
-      document.documentElement.scrollTo({ behavior: 'smooth', top: 0 });
-    });
-
-    const observer = new IntersectionObserver(callback);
-    observer.observe(targetHeader);
-  }
-</script>

--- a/src/lib/client/auth-check.test.ts
+++ b/src/lib/client/auth-check.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { checkAuth, clearAuthCache } from './auth-check.ts';
+
+describe('checkAuth', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    clearAuthCache();
+  });
+
+  it('fetches /api/auth-status without requiring a readable session cookie', async () => {
+    let requestedUrl = '';
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input);
+      return new Response(JSON.stringify({ isAuthenticated: true }), { status: 200 });
+    }) as typeof fetch;
+
+    assert.equal(await checkAuth(), true);
+    assert.equal(requestedUrl, '/api/auth-status');
+  });
+
+  it('caches the auth result across calls', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ isAuthenticated: false }), { status: 200 });
+    }) as typeof fetch;
+
+    assert.equal(await checkAuth(), false);
+    assert.equal(await checkAuth(), false);
+    assert.equal(calls, 1);
+  });
+
+  it('returns false when the auth status request fails', async () => {
+    globalThis.fetch = (async () => {
+      throw new Error('network down');
+    }) as typeof fetch;
+
+    assert.equal(await checkAuth(), false);
+  });
+
+  it('returns false for non-OK responses', async () => {
+    globalThis.fetch = (async () => new Response('nope', { status: 500 })) as typeof fetch;
+
+    assert.equal(await checkAuth(), false);
+  });
+
+  it('clearAuthCache forces a fresh request', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ isAuthenticated: true }), { status: 200 });
+    }) as typeof fetch;
+
+    assert.equal(await checkAuth(), true);
+    clearAuthCache();
+    assert.equal(await checkAuth(), true);
+    assert.equal(calls, 2);
+  });
+});

--- a/src/lib/client/auth-check.ts
+++ b/src/lib/client/auth-check.ts
@@ -1,23 +1,14 @@
-import { SESSION_COOKIE_NAME } from '../session-cookie';
-
 interface AuthStatusResponse {
   isAuthenticated: boolean;
 }
 
 let authPromise: Promise<boolean> | null = null;
 
-function hasSessionCookie(): boolean {
-  return document.cookie.split(';').some((part) => {
-    const [name] = part.trim().split('=');
-    return name === SESSION_COOKIE_NAME;
-  });
-}
-
+/**
+ * Check admin auth via the server. Session cookies are httpOnly, so we cannot
+ * gate on document.cookie — always ask /api/auth-status (result is cached).
+ */
 export function checkAuth(): Promise<boolean> {
-  if (!hasSessionCookie()) {
-    return Promise.resolve(false);
-  }
-
   if (!authPromise) {
     authPromise = fetch('/api/auth-status')
       .then((r) => (r.ok ? (r.json() as Promise<AuthStatusResponse>) : { isAuthenticated: false }))
@@ -26,4 +17,9 @@ export function checkAuth(): Promise<boolean> {
   }
 
   return authPromise;
+}
+
+/** Clear the cached auth result (e.g. after logout). */
+export function clearAuthCache(): void {
+  authPromise = null;
 }

--- a/src/lib/comments-config.ts
+++ b/src/lib/comments-config.ts
@@ -1,0 +1,2 @@
+/** Single source of truth for the Respectify comments list API path. */
+export const COMMENTS_API_PATH = '/api/comments';

--- a/src/lib/memory-rate-limit.test.ts
+++ b/src/lib/memory-rate-limit.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createMemoryRateLimiter } from './memory-rate-limit.ts';
+
+describe('createMemoryRateLimiter', () => {
+  it('allows requests under the limit', async () => {
+    const limiter = createMemoryRateLimiter({ windowMs: 60_000, maxRequests: 3 });
+
+    assert.equal((await limiter.check('a')).allowed, true);
+    assert.equal((await limiter.check('a')).allowed, true);
+    assert.equal((await limiter.check('a')).allowed, true);
+  });
+
+  it('blocks once the limit is exceeded', async () => {
+    const limiter = createMemoryRateLimiter({ windowMs: 60_000, maxRequests: 2 });
+
+    assert.equal((await limiter.check('b')).allowed, true);
+    assert.equal((await limiter.check('b')).allowed, true);
+
+    const blocked = await limiter.check('b');
+    assert.equal(blocked.allowed, false);
+    assert.ok(blocked.retryAfterMs >= 1000);
+  });
+
+  it('tracks keys independently', async () => {
+    const limiter = createMemoryRateLimiter({ windowMs: 60_000, maxRequests: 1 });
+
+    assert.equal((await limiter.check('one')).allowed, true);
+    assert.equal((await limiter.check('one')).allowed, false);
+    assert.equal((await limiter.check('two')).allowed, true);
+  });
+});

--- a/src/lib/memory-rate-limit.ts
+++ b/src/lib/memory-rate-limit.ts
@@ -1,0 +1,68 @@
+export interface MemoryRateLimitConfig {
+  windowMs: number;
+  maxRequests: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retryAfterMs: number;
+}
+
+export interface IRateLimiter {
+  check(key: string): Promise<RateLimitResult>;
+}
+
+/** Sliding-window rate limiter kept entirely in process memory. */
+export class SlidingWindowRateLimiter implements IRateLimiter {
+  private readonly requests = new Map<string, number[]>();
+  private readonly windowMs: number;
+  private readonly maxRequests: number;
+  private cleanupTimer: ReturnType<typeof setInterval>;
+
+  constructor(config: MemoryRateLimitConfig) {
+    this.windowMs = config.windowMs;
+    this.maxRequests = config.maxRequests;
+
+    this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
+
+    if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  check(key: string): Promise<RateLimitResult> {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    const timestamps = this.requests.get(key) ?? [];
+    const valid = timestamps.filter((t) => t > windowStart);
+
+    if (valid.length >= this.maxRequests) {
+      const oldestInWindow = valid[0]!;
+      const retryAfterMs = oldestInWindow + this.windowMs - now;
+      return Promise.resolve({ allowed: false, retryAfterMs: Math.max(retryAfterMs, 1000) });
+    }
+
+    valid.push(now);
+    this.requests.set(key, valid);
+    return Promise.resolve({ allowed: true, retryAfterMs: 0 });
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    const windowStart = now - this.windowMs;
+
+    for (const [key, timestamps] of this.requests) {
+      const valid = timestamps.filter((t) => t > windowStart);
+      if (valid.length === 0) {
+        this.requests.delete(key);
+      } else {
+        this.requests.set(key, valid);
+      }
+    }
+  }
+}
+
+export function createMemoryRateLimiter(config: MemoryRateLimitConfig): IRateLimiter {
+  return new SlidingWindowRateLimiter(config);
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,70 +1,19 @@
 import { getRedisClient } from './redis';
 import { logger } from './logger';
+import {
+  createMemoryRateLimiter,
+  SlidingWindowRateLimiter,
+  type IRateLimiter,
+  type RateLimitResult,
+} from './memory-rate-limit';
+
+export type { IRateLimiter, RateLimitResult };
+export { createMemoryRateLimiter };
 
 interface RateLimitConfig {
   windowMs: number;
   maxRequests: number;
   prefix: string;
-}
-
-interface RateLimitResult {
-  allowed: boolean;
-  retryAfterMs: number;
-}
-
-export interface IRateLimiter {
-  check(key: string): Promise<RateLimitResult>;
-}
-
-class SlidingWindowRateLimiter implements IRateLimiter {
-  private readonly requests = new Map<string, number[]>();
-  private readonly windowMs: number;
-  private readonly maxRequests: number;
-  private cleanupTimer: ReturnType<typeof setInterval>;
-
-  constructor(config: Omit<RateLimitConfig, 'prefix'>) {
-    this.windowMs = config.windowMs;
-    this.maxRequests = config.maxRequests;
-
-    this.cleanupTimer = setInterval(() => this.cleanup(), 60_000);
-
-    if (typeof this.cleanupTimer === 'object' && 'unref' in this.cleanupTimer) {
-      this.cleanupTimer.unref();
-    }
-  }
-
-  check(key: string): Promise<RateLimitResult> {
-    const now = Date.now();
-    const windowStart = now - this.windowMs;
-
-    const timestamps = this.requests.get(key) ?? [];
-    const valid = timestamps.filter((t) => t > windowStart);
-
-    if (valid.length >= this.maxRequests) {
-      const oldestInWindow = valid[0]!;
-      const retryAfterMs = oldestInWindow + this.windowMs - now;
-      logger.warn(`[rate-limit] Blocked request for key: ${key} (${valid.length}/${this.maxRequests})`);
-      return Promise.resolve({ allowed: false, retryAfterMs: Math.max(retryAfterMs, 1000) });
-    }
-
-    valid.push(now);
-    this.requests.set(key, valid);
-    return Promise.resolve({ allowed: true, retryAfterMs: 0 });
-  }
-
-  private cleanup(): void {
-    const now = Date.now();
-    const windowStart = now - this.windowMs;
-
-    for (const [key, timestamps] of this.requests) {
-      const valid = timestamps.filter((t) => t > windowStart);
-      if (valid.length === 0) {
-        this.requests.delete(key);
-      } else {
-        this.requests.set(key, valid);
-      }
-    }
-  }
 }
 
 class RedisSlidingWindowRateLimiter implements IRateLimiter {

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -7,12 +7,9 @@ const rateLimitedRoutes: Record<string, IRateLimiter> = {
   '/_actions/comments.submit': commentLimiter,
 };
 
-function getClientIp(request: Request, clientAddress: string | undefined): string {
-  const forwarded = request.headers.get('x-forwarded-for');
-  if (forwarded) {
-    return forwarded.split(',')[0]!.trim();
-  }
-  return clientAddress ?? 'unknown';
+/** Prefer platform-provided clientAddress; X-Forwarded-For is spoofable. */
+function getClientIp(clientAddress: string | undefined): string {
+  return clientAddress?.trim() || 'unknown';
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {
@@ -20,7 +17,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
   const limiter = rateLimitedRoutes[pathname];
 
   if (limiter && context.request.method === 'POST') {
-    const ip = getClientIp(context.request, context.clientAddress);
+    const ip = getClientIp(context.clientAddress);
     const key = `${ip}:${pathname}`;
     const result = await limiter.check(key);
 

--- a/src/pages/info/[slug].astro
+++ b/src/pages/info/[slug].astro
@@ -25,9 +25,9 @@ if (!entry) {
   return Astro.redirect('/404');
 }
 
-const { Content } = await render(entry);
+const { Content, headings } = await render(entry);
 ---
 
-<InfoLayout info={entry}>
-  <article class="prose prose-cactus"><Content /></article>
+<InfoLayout info={entry} headings={headings}>
+  <Content />
 </InfoLayout>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -23,11 +23,8 @@ const title = 'Admin Login';
       }
 
       body {
-        font-family:
-          system-ui,
-          -apple-system,
-          sans-serif;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        font-family: var(--font-mono, ui-monospace, monospace), system-ui, sans-serif;
+        background: #1d1f21;
         min-height: 100vh;
         display: flex;
         align-items: center;
@@ -36,9 +33,10 @@ const title = 'Admin Login';
       }
 
       .login-container {
-        background: white;
-        border-radius: 1rem;
-        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        background: #fafafa;
+        border-radius: 0.5rem;
+        border-top: 3px solid #2bbc89;
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
         padding: 3rem 2rem;
         width: 100%;
         max-width: 400px;
@@ -145,15 +143,15 @@ const title = 'Admin Login';
   </head>
   <body>
     <div class="login-container">
-      <h1>🔐 Admin Login</h1>
+      <h1>Admin Login</h1>
       <p class="subtitle">Sign in to access admin features</p>
 
       <div id="message" class="message"></div>
 
-      <form id="login-form" method="POST" action="/login">
+      <form id="login-form" method="POST">
         <div class="form-group">
           <label for="email">Email</label>
-          <input type="email" id="email" name="email" required autocomplete="email" placeholder="nickhodges@gmail.com" />
+          <input type="email" id="email" name="email" required autocomplete="email" placeholder="you@example.com" />
         </div>
 
         <div class="form-group">

--- a/src/pages/og-image/[...slug].png.ts
+++ b/src/pages/og-image/[...slug].png.ts
@@ -9,6 +9,7 @@ import { Resvg } from '@resvg/resvg-js';
 import { siteConfig } from '@site-config';
 import { getFormattedDate } from '@utils';
 import { getAllPosts } from '@data/post';
+import { getAllDelphiPosts } from '@data/delphi';
 
 const RobotoMono = readFileSync(join(process.cwd(), 'src/assets/roboto-mono-regular.ttf'));
 const RobotoMonoBold = readFileSync(join(process.cwd(), 'src/assets/roboto-mono-700.ttf'));
@@ -76,7 +77,9 @@ export async function GET(context: APIContext) {
 
 export async function getStaticPaths() {
   const posts = await getAllPosts();
-  return posts
+  const delphiPosts = await getAllDelphiPosts();
+  const allPosts = [...posts, ...delphiPosts];
+  return allPosts
     .filter(({ data }) => !data.ogImage)
     .map((post) => ({
       params: { slug: post.id },

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -24,9 +24,9 @@ export const getStaticPaths = (async () => {
 type Props = InferGetStaticPropsType<typeof getStaticPaths>;
 
 const { entry } = Astro.props;
-const { Content } = await render(entry);
+const { Content, headings, remarkPluginFrontmatter } = await render(entry);
 ---
 
-<PostLayout post={entry}>
+<PostLayout post={entry} headings={headings} minutesRead={remarkPluginFrontmatter.minutesRead}>
   <Content />
 </PostLayout>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,15 +3,19 @@ export const prerender = true;
 import rss from '@astrojs/rss';
 import { siteConfig } from '@site-config';
 import { getAllPosts } from '@data/post';
+import { getAllDelphiPosts } from '@data/delphi';
+import { sortMDByDate } from '@data/collection-helpers';
 
 export const GET = async () => {
   const posts = await getAllPosts();
+  const delphiPosts = await getAllDelphiPosts();
+  const items = sortMDByDate([...posts, ...delphiPosts]);
 
   return rss({
     title: siteConfig.title,
     description: siteConfig.description,
     site: import.meta.env.SITE,
-    items: posts.map((post) => ({
+    items: items.map((post) => ({
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.publishDate,

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -22,8 +22,8 @@ export const siteConfig: SiteConfig = {
   },
   // Google AdSense Configuration
   adsense: {
-    clientId: 'ca-pub-9957327027530940', // Replace with your AdSense publisher ID
-    adSlot: '6617379235', // Replace with your ad slot ID
+    clientId: 'ca-pub-9957327027530940',
+    adSlot: '6617379235',
   },
 };
 


### PR DESCRIPTION
## Summary
- Fix broken client auth check (httpOnly session cookie), await session regenerate on login, and wire logout UI
- Include Delphi posts in OG images and RSS; share post/delphi data helpers; single `render()` per post
- Gate AdSense behind cookie consent, harden rate-limit IP trust, and clean up client/lifecycle/Pagefind polish

## Test plan
- [ ] `npm test` and `npm run check` pass
- [ ] Log in as admin and confirm avatar ring + Log out work
- [ ] Decline cookies: no AdSense script; accept cookies: ads load
- [ ] Open a Delphi post and confirm OG image path resolves
- [ ] Confirm `/rss.xml` includes both main and Delphi posts


Made with [Cursor](https://cursor.com)